### PR TITLE
feat: custom landing pages for every variant and project

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -60,6 +60,17 @@ const config: Config = {
       },
       items: [
         {
+          type: 'dropdown',
+          label: 'Variants',
+          position: 'left',
+          items: [
+            {to: '/albacore', label: '🐟 Albacore — AlmaLinux 10'},
+            {to: '/yellowfin', label: '🐠 Yellowfin — AlmaLinux Kitten'},
+            {to: '/skipjack', label: '🍣 Skipjack — CentOS Stream 10'},
+            {to: '/bonito', label: '🎣 Bonito — Fedora 44'},
+          ],
+        },
+        {
           to: '/projects',
           label: 'Projects',
           position: 'left',
@@ -107,19 +118,19 @@ const config: Config = {
           items: [
             {
               label: 'Albacore (AlmaLinux)',
-              to: 'docs/albacore',
+              to: '/albacore',
             },
             {
               label: 'Yellowfin (AlmaLinux Kitten)',
-              to: 'docs/yellowfin',
+              to: '/yellowfin',
             },
             {
               label: 'Bonito (Fedora)',
-              to: 'docs/bonito',
+              to: '/bonito',
             },
             {
               label: 'Skipjack (CentOS)',
-              to: 'docs/skipjack',
+              to: '/skipjack',
             },
           ],
         },

--- a/src/components/ProjectCards/index.tsx
+++ b/src/components/ProjectCards/index.tsx
@@ -15,7 +15,7 @@ type Project = {
 const PROJECTS: Project[] = [
   {
     name: 'TunaOS',
-    slug: '/docs/tunaos',
+    slug: '/tunaos',
     icon: '🐟',
     description: 'Cloud-native Enterprise Linux desktop images built with bootc. GNOME, KDE, COSMIC, Niri on AlmaLinux, CentOS Stream, and Fedora.',
     status: 'stable',
@@ -27,7 +27,7 @@ const PROJECTS: Project[] = [
   },
   {
     name: 'Tacklebox',
-    slug: '/docs/tacklebox',
+    slug: '/tacklebox',
     icon: '🛠',
     description: 'High-performance bootc orchestrator. Produces multi-boot USB drives, disk images, and deduplicated ISOs from OCI container images.',
     status: 'stable',
@@ -38,7 +38,7 @@ const PROJECTS: Project[] = [
   },
   {
     name: 'Tromsø',
-    slug: '/docs/tromso',
+    slug: '/tromso',
     icon: '🌋',
     description: 'A BuildStream-based KDE Linux distribution. Builds desktop OS images from source with reproducible pipelines.',
     status: 'alpha',
@@ -49,7 +49,7 @@ const PROJECTS: Project[] = [
   },
   {
     name: 'XFCE Linux',
-    slug: '/docs/xfce-linux',
+    slug: '/xfce-linux',
     icon: '🖥️',
     description: 'XFCE Wayland OCI image built with BuildStream. A lightweight desktop experience on an immutable base.',
     status: 'alpha',
@@ -71,7 +71,7 @@ const PROJECTS: Project[] = [
   },
   {
     name: 'Tavern',
-    slug: '/docs/tavern',
+    slug: '/tavern',
     icon: '🍻',
     description: 'A modern, fast Homebrew client for Linux built with GTK 4 and Libadwaita. App Store experience for managing formulae and casks.',
     status: 'stable',
@@ -82,7 +82,7 @@ const PROJECTS: Project[] = [
   },
   {
     name: 'bluefin-cli',
-    slug: '/docs/bluefin-cli',
+    slug: '/bluefin-cli',
     icon: '⌨️',
     description: 'Powerful CLI tool for shell configuration and dev environment customization. Beautiful TUIs built with Charm libraries.',
     status: 'stable',

--- a/src/components/ProjectLanding/index.tsx
+++ b/src/components/ProjectLanding/index.tsx
@@ -1,0 +1,166 @@
+import type {ReactNode} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+import AnimatedEmoji from '@site/src/components/AnimatedEmoji';
+import {PROJECTS, STATUS_LABELS, type Project} from '@site/src/data/projects';
+
+import styles from './styles.module.css';
+
+function Hero({project}: {project: Project}): ReactNode {
+  const style = {
+    ['--p-accent' as string]: project.accent,
+    ['--p-accent2' as string]: project.accent2,
+  };
+  return (
+    <header className={styles.hero} style={style}>
+      <div className={clsx('container', styles.heroInner)}>
+        <div className={styles.heroEmoji}>
+          <AnimatedEmoji emoji={project.emoji} size={92} />
+        </div>
+        <div className={styles.heroTitleRow}>
+          <Heading as="h1" className={styles.heroTitle}>{project.name}</Heading>
+          <span className={clsx(styles.status, styles[`status-${project.status}`])}>
+            {STATUS_LABELS[project.status]}
+          </span>
+        </div>
+        <p className={styles.heroTagline}>{project.tagline}</p>
+        <p className={styles.heroLede}>{project.lede}</p>
+
+        {project.stats && (
+          <div className={styles.statRow}>
+            {project.stats.map((s) => (
+              <div key={s.label} className={styles.statChip}>
+                <span className={styles.statValue}>{s.value}</span>
+                <span className={styles.statLabel}>{s.label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className={styles.heroButtons}>
+          {project.cta && (
+            <Link className={clsx('button button--lg', styles.btnPrimary)} to={project.cta.to}>
+              {project.cta.label}
+            </Link>
+          )}
+          <Link
+            className={clsx('button button--lg', project.cta ? styles.btnGhost : styles.btnPrimary)}
+            to={project.docs}>
+            Documentation 📖
+          </Link>
+          <a className={clsx('button button--lg', styles.btnGhost)} href={project.repo}>
+            GitHub 💻
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function Screenshots({project}: {project: Project}): ReactNode {
+  if (!project.screenshots?.length) return null;
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">See it in action</Heading>
+        </div>
+        <div className={styles.shotGrid}>
+          {project.screenshots.map((s) => (
+            <figure key={s.src} className={styles.shot}>
+              <img src={s.src} alt={s.alt} loading="lazy" />
+              <figcaption>{s.alt}</figcaption>
+            </figure>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Features({project}: {project: Project}): ReactNode {
+  return (
+    <section className={clsx(styles.section, styles.sectionAlt)}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">Features</Heading>
+        </div>
+        <div className={styles.featGrid}>
+          {project.features.map((f) => (
+            <div key={f.title} className={styles.featCard}>
+              <span className={styles.featEmoji}><AnimatedEmoji emoji={f.emoji} size={30} /></span>
+              <Heading as="h3" className={styles.featTitle}>{f.title}</Heading>
+              <p className={styles.featText}>{f.text}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Install({project}: {project: Project}): ReactNode {
+  if (!project.install?.length) return null;
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">Get started</Heading>
+        </div>
+        <div className={styles.installList}>
+          {project.install.map((i) => (
+            <div key={i.label} className={styles.installItem}>
+              <span className={styles.installLabel}>{i.label}</span>
+              <pre className={styles.installCode}><code>{i.code}</code></pre>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MoreProjects({project}: {project: Project}): ReactNode {
+  const others = PROJECTS.filter((p) => p.id !== project.id);
+  return (
+    <section className={clsx(styles.section, styles.sectionAlt)}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">More from TunaOS</Heading>
+        </div>
+        <div className={styles.otherGrid}>
+          {others.map((p) => (
+            <Link key={p.id} to={`/${p.id}`} className={styles.otherCard}>
+              <span className={styles.otherEmoji}><AnimatedEmoji emoji={p.emoji} size={30} /></span>
+              <span>
+                <strong className={styles.otherName}>{p.name}</strong>
+                <span className={styles.otherTagline}>{p.tagline}</span>
+              </span>
+            </Link>
+          ))}
+        </div>
+        <div className="text--center margin-top--md">
+          <Link className="button button--outline button--md" to="/projects">
+            All projects →
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function ProjectLanding({project}: {project: Project}): ReactNode {
+  return (
+    <Layout title={project.name} description={project.tagline}>
+      <Hero project={project} />
+      <main>
+        <Screenshots project={project} />
+        <Features project={project} />
+        <Install project={project} />
+        <MoreProjects project={project} />
+      </main>
+    </Layout>
+  );
+}

--- a/src/components/ProjectLanding/styles.module.css
+++ b/src/components/ProjectLanding/styles.module.css
@@ -1,0 +1,134 @@
+/* Per-project landing page. Accent colours arrive as --p-accent /
+   --p-accent2 custom properties set inline per project. */
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 4.5rem 1rem 3.5rem;
+  text-align: center;
+  color: #fff;
+  background: radial-gradient(120% 120% at 50% -10%, var(--p-accent2) 0%, var(--p-accent) 60%, #0b1220 100%);
+}
+.heroInner { position: relative; z-index: 2; max-width: 820px; }
+.heroEmoji { filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.35)); }
+
+.heroTitleRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+}
+.heroTitle {
+  font-size: clamp(2.4rem, 6vw, 3.8rem);
+  margin: 0;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  text-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+.status {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+.status-alpha { background: rgba(245, 158, 11, 0.35); }
+.status-experimental { background: rgba(239, 68, 68, 0.35); }
+.status-internal { background: rgba(148, 163, 184, 0.35); }
+
+.heroTagline { margin: 1rem auto 0; max-width: 620px; font-size: 1.2rem; font-weight: 600; opacity: 0.97; }
+.heroLede { margin: 0.85rem auto 0; max-width: 640px; font-size: 1.05rem; line-height: 1.6; opacity: 0.92; }
+
+.statRow { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.7rem; margin: 1.6rem 0 0.25rem; }
+.statChip {
+  display: flex; flex-direction: column; align-items: center;
+  min-width: 110px; padding: 0.55rem 1rem; border-radius: 14px;
+  background: rgba(255, 255, 255, 0.14); border: 1px solid rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(6px);
+}
+.statValue { font-weight: 800; font-size: 0.95rem; }
+.statLabel { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.85; }
+
+.heroButtons { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.8rem; margin-top: 1.9rem; }
+.btnPrimary { background: #fff; color: #0b1220 !important; border: none; font-weight: 700; }
+.btnPrimary:hover { background: #f1f5f9; color: #0b1220 !important; transform: translateY(-2px); }
+.btnGhost {
+  background: rgba(255, 255, 255, 0.1); color: #fff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55); font-weight: 600;
+}
+.btnGhost:hover { background: rgba(255, 255, 255, 0.2); transform: translateY(-2px); }
+
+/* Sections */
+.section { padding: 4rem 1rem; }
+.sectionAlt { background: var(--ifm-color-emphasis-100); }
+.sectionHead { text-align: center; max-width: 680px; margin: 0 auto 2.5rem; }
+.sectionHead h2 { font-size: clamp(1.7rem, 4vw, 2.3rem); font-weight: 800; margin-bottom: 0.5rem; }
+
+/* Screenshots */
+.shotGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+.shot { margin: 0; }
+.shot img {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  display: block;
+}
+.shot figcaption {
+  margin-top: 0.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* Features */
+.featGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+.featCard {
+  padding: 1.5rem; border-radius: 16px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+.featEmoji { display: inline-block; margin-bottom: 0.6rem; }
+.featTitle { font-size: 1.12rem; margin: 0 0 0.4rem; }
+.featText { color: var(--ifm-color-emphasis-700); margin: 0; line-height: 1.55; }
+
+/* Install */
+.installList { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 1.25rem; }
+.installLabel {
+  display: block; font-size: 0.8rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-600); margin-bottom: 0.4rem;
+}
+.installCode { margin: 0; border-radius: 12px; border: 1px solid var(--ifm-color-emphasis-200); }
+
+/* More projects */
+.otherGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.otherCard {
+  display: flex; align-items: center; gap: 0.85rem;
+  padding: 1.1rem 1.2rem; border-radius: 14px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  text-decoration: none !important;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.otherCard:hover { transform: translateY(-3px); box-shadow: 0 10px 24px rgba(0, 0, 0, 0.1); }
+.otherEmoji { flex: none; }
+.otherName { display: block; color: var(--ifm-heading-color); font-size: 1.05rem; }
+.otherTagline { display: block; font-size: 0.85rem; color: var(--ifm-color-emphasis-700); margin-top: 0.2rem; }

--- a/src/components/VariantLanding/index.tsx
+++ b/src/components/VariantLanding/index.tsx
@@ -1,0 +1,200 @@
+import type {ReactNode} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+import AnimatedEmoji from '@site/src/components/AnimatedEmoji';
+import {VARIANTS, type Variant} from '@site/src/data/variants';
+
+import styles from './styles.module.css';
+
+function Hero({variant}: {variant: Variant}): ReactNode {
+  // Per-variant accent gradient, injected as CSS custom properties.
+  const style = {
+    ['--v-accent' as string]: variant.accent,
+    ['--v-accent2' as string]: variant.accent2,
+  };
+  return (
+    <header className={styles.hero} style={style}>
+      <div className={styles.heroBubbles} aria-hidden>
+        {Array.from({length: 14}).map((_, i) => (
+          <span key={i} className={styles.bubble} />
+        ))}
+      </div>
+      <div className={clsx('container', styles.heroInner)}>
+        {variant.recommended && <span className={styles.recommendedTag}>★ Recommended</span>}
+        <div className={styles.heroEmoji}>
+          <AnimatedEmoji emoji={variant.emoji} size={104} />
+        </div>
+        <Heading as="h1" className={styles.heroTitle}>
+          {variant.name}
+        </Heading>
+        <a className={styles.heroBase} href={variant.baseUrl} target="_blank" rel="noreferrer">
+          Based on {variant.base} ↗
+        </a>
+        <p className={styles.heroLede}>{variant.lede}</p>
+
+        <div className={styles.statRow}>
+          {variant.stats.map((s) => (
+            <div key={s.label} className={styles.statChip}>
+              <span className={styles.statValue}>{s.value}</span>
+              <span className={styles.statLabel}>{s.label}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.heroButtons}>
+          <Link className={clsx('button button--lg', styles.btnPrimary)} to="/download">
+            {variant.hasIsos ? 'Download ISO 📦' : 'Browse images 📦'}
+          </Link>
+          <Link className={clsx('button button--lg', styles.btnGhost)} to={`/docs/${variant.id}`}>
+            Full docs 📖
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function Desktops({variant}: {variant: Variant}): ReactNode {
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">One base, every desktop</Heading>
+          <p>Each {variant.name} flavor ships a different desktop on the same {variant.base} foundation.</p>
+        </div>
+        <div className={styles.deskGrid}>
+          {variant.desktops.map((d) => (
+            <div key={d.tag} className={styles.deskCard}>
+              <span className={styles.deskEmoji}><AnimatedEmoji emoji={d.emoji} size={36} /></span>
+              <Heading as="h3" className={styles.deskName}>{d.name}</Heading>
+              <p className={styles.deskBlurb}>{d.blurb}</p>
+              <code className={styles.deskTag}>:{d.tag}</code>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Features({variant}: {variant: Variant}): ReactNode {
+  return (
+    <section className={clsx(styles.section, styles.sectionAlt)}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">Why {variant.name}</Heading>
+        </div>
+        <div className={styles.featGrid}>
+          {variant.features.map((f) => (
+            <div key={f.title} className={styles.featCard}>
+              <span className={styles.featEmoji}><AnimatedEmoji emoji={f.emoji} size={32} /></span>
+              <Heading as="h3" className={styles.featTitle}>{f.title}</Heading>
+              <p className={styles.featText}>{f.text}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Flavors({variant}: {variant: Variant}): ReactNode {
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">Images & flavors</Heading>
+          <p>Pull any flavor directly, or rebase an existing bootc system onto it.</p>
+        </div>
+        <div className={styles.flavorTable}>
+          {variant.flavors.map((f) => (
+            <div key={f.image} className={styles.flavorRow}>
+              <span className={styles.flavorName}>
+                {f.name}
+                {f.note && <span className={styles.flavorNote}>{f.note}</span>}
+              </span>
+              <code className={styles.flavorImage}>{f.image}</code>
+            </div>
+          ))}
+        </div>
+        <div className={styles.rebaseBox}>
+          <span className={styles.rebaseLabel}>Rebase an existing bootc system</span>
+          <pre className={styles.rebaseCode}>
+            <code>{`sudo bootc switch ${variant.flavors[0].image}`}</code>
+          </pre>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function OtherVariants({variant}: {variant: Variant}): ReactNode {
+  const others = VARIANTS.filter((v) => v.id !== variant.id);
+  return (
+    <section className={clsx(styles.section, styles.sectionAlt)}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">Prefer a different cadence?</Heading>
+          <p>Same desktops, same tooling — pick the base that fits you.</p>
+        </div>
+        <div className={styles.otherGrid}>
+          {others.map((v) => (
+            <Link key={v.id} to={`/${v.id}`} className={styles.otherCard}>
+              <span className={styles.otherEmoji}><AnimatedEmoji emoji={v.emoji} size={34} /></span>
+              <div>
+                <strong className={styles.otherName}>{v.name}</strong>
+                <span className={styles.otherBase}>{v.base}</span>
+                <span className={styles.otherBlurb}>{v.blurb}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Cta({variant}: {variant: Variant}): ReactNode {
+  const style = {
+    ['--v-accent' as string]: variant.accent,
+    ['--v-accent2' as string]: variant.accent2,
+  };
+  return (
+    <section className={styles.ctaBand} style={style}>
+      <div className="container text--center">
+        <div className={styles.ctaEmoji}><AnimatedEmoji emoji={variant.emoji} size={56} /></div>
+        <Heading as="h2" className={styles.ctaTitle}>Dive into {variant.name}</Heading>
+        <p className={styles.ctaText}>
+          Grab a live ISO, or rebase an existing bootc system in one command.
+        </p>
+        <div className={styles.heroButtons}>
+          <Link className={clsx('button button--lg', styles.btnPrimary)} to="/download">
+            Download 📦
+          </Link>
+          <Link className={clsx('button button--lg', styles.btnGhost)} to="/docs/installation">
+            Install guide 📋
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function VariantLanding({variant}: {variant: Variant}): ReactNode {
+  return (
+    <Layout
+      title={`${variant.name} — ${variant.base}`}
+      description={variant.blurb}>
+      <Hero variant={variant} />
+      <main>
+        <Desktops variant={variant} />
+        <Features variant={variant} />
+        <Flavors variant={variant} />
+        <OtherVariants variant={variant} />
+        <Cta variant={variant} />
+      </main>
+    </Layout>
+  );
+}

--- a/src/components/VariantLanding/styles.module.css
+++ b/src/components/VariantLanding/styles.module.css
@@ -1,0 +1,288 @@
+/* Per-variant landing page. Accent colours come in as --v-accent /
+   --v-accent2 custom properties set inline per variant. */
+
+/* ── Hero ───────────────────────────────────────────────────────────────── */
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 5rem 1rem 4rem;
+  text-align: center;
+  color: #fff;
+  background:
+    radial-gradient(120% 120% at 50% -10%, var(--v-accent2) 0%, var(--v-accent) 55%, #0b1220 100%);
+}
+
+.heroInner {
+  position: relative;
+  z-index: 2;
+  max-width: 820px;
+}
+
+.heroEmoji {
+  filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.35));
+  animation: float 5s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+
+.recommendedTag {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+  padding: 0.25rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(4px);
+}
+
+.heroTitle {
+  font-size: clamp(2.6rem, 7vw, 4.2rem);
+  margin: 0.25rem 0 0.4rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  text-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.heroBase {
+  display: inline-block;
+  color: #fff;
+  font-weight: 600;
+  opacity: 0.92;
+  text-decoration: none;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.5);
+}
+.heroBase:hover { opacity: 1; color: #fff; }
+
+.heroLede {
+  margin: 1.25rem auto 0;
+  max-width: 640px;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  opacity: 0.95;
+}
+
+.statRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 1.75rem 0 0.5rem;
+}
+
+.statChip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 110px;
+  padding: 0.6rem 1rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(6px);
+}
+.statValue { font-weight: 800; font-size: 1.05rem; }
+.statLabel { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.85; }
+
+.heroButtons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.85rem;
+  margin-top: 2rem;
+}
+
+.btnPrimary {
+  background: #fff;
+  color: #0b1220 !important;
+  border: none;
+  font-weight: 700;
+}
+.btnPrimary:hover { background: #f1f5f9; color: #0b1220 !important; transform: translateY(-2px); }
+
+.btnGhost {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff !important;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  font-weight: 600;
+}
+.btnGhost:hover { background: rgba(255, 255, 255, 0.2); transform: translateY(-2px); }
+
+/* Floating bubbles */
+.heroBubbles { position: absolute; inset: 0; z-index: 1; pointer-events: none; }
+.bubble {
+  position: absolute;
+  bottom: -40px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  animation: rise linear infinite;
+}
+.bubble:nth-child(odd) { width: 10px; height: 10px; }
+.bubble:nth-child(1) { left: 6%; animation-duration: 9s; }
+.bubble:nth-child(2) { left: 14%; animation-duration: 12s; animation-delay: 1s; }
+.bubble:nth-child(3) { left: 23%; animation-duration: 8s; animation-delay: 2s; }
+.bubble:nth-child(4) { left: 32%; animation-duration: 14s; }
+.bubble:nth-child(5) { left: 41%; animation-duration: 10s; animation-delay: 3s; }
+.bubble:nth-child(6) { left: 50%; animation-duration: 11s; animation-delay: 1s; }
+.bubble:nth-child(7) { left: 59%; animation-duration: 9s; animation-delay: 2s; }
+.bubble:nth-child(8) { left: 68%; animation-duration: 13s; }
+.bubble:nth-child(9) { left: 77%; animation-duration: 8s; animation-delay: 2s; }
+.bubble:nth-child(10) { left: 84%; animation-duration: 12s; animation-delay: 1s; }
+.bubble:nth-child(11) { left: 90%; animation-duration: 10s; animation-delay: 3s; }
+.bubble:nth-child(12) { left: 96%; animation-duration: 11s; }
+.bubble:nth-child(13) { left: 3%; animation-duration: 15s; }
+.bubble:nth-child(14) { left: 47%; animation-duration: 7s; animation-delay: 2s; }
+
+@keyframes rise {
+  0% { transform: translateY(0) scale(1); opacity: 0; }
+  10% { opacity: 1; }
+  100% { transform: translateY(-115vh) scale(1.3); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heroEmoji, .bubble { animation: none; }
+}
+
+/* ── Sections ───────────────────────────────────────────────────────────── */
+.section { padding: 4rem 1rem; }
+.sectionAlt { background: var(--ifm-color-emphasis-100); }
+
+.sectionHead { text-align: center; max-width: 680px; margin: 0 auto 2.5rem; }
+.sectionHead h2 { font-size: clamp(1.7rem, 4vw, 2.3rem); font-weight: 800; margin-bottom: 0.5rem; }
+.sectionHead p { color: var(--ifm-color-emphasis-700); font-size: 1.05rem; margin: 0; }
+
+/* Desktops */
+.deskGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.1rem;
+}
+.deskCard {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 16px;
+  padding: 1.4rem;
+  text-align: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.deskCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.1);
+  border-color: var(--v-accent, var(--ifm-color-primary));
+}
+.deskEmoji { display: inline-block; margin-bottom: 0.5rem; }
+.deskName { font-size: 1.15rem; margin: 0 0 0.35rem; }
+.deskBlurb { font-size: 0.9rem; color: var(--ifm-color-emphasis-700); margin: 0 0 0.75rem; line-height: 1.45; }
+.deskTag {
+  font-size: 0.78rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 6px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+}
+
+/* Features */
+.featGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+.featCard {
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+.featEmoji { display: inline-block; margin-bottom: 0.6rem; }
+.featTitle { font-size: 1.15rem; margin: 0 0 0.4rem; }
+.featText { color: var(--ifm-color-emphasis-700); margin: 0; line-height: 1.55; }
+
+/* Flavors table */
+.flavorTable {
+  max-width: 760px;
+  margin: 0 auto;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.flavorRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  padding: 0.85rem 1.1rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+.flavorRow:last-child { border-bottom: none; }
+.flavorRow:nth-child(odd) { background: var(--ifm-color-emphasis-100); }
+.flavorName { font-weight: 700; display: flex; align-items: center; gap: 0.6rem; }
+.flavorNote {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.12rem 0.45rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--v-accent, #16a34a) 18%, transparent);
+  color: var(--v-accent, #16a34a);
+}
+.flavorImage { font-size: 0.82rem; color: var(--ifm-color-emphasis-800); }
+
+.rebaseBox {
+  max-width: 760px;
+  margin: 1.5rem auto 0;
+}
+.rebaseLabel {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.4rem;
+}
+.rebaseCode {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+/* Other variants */
+.otherGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+.otherCard {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1.1rem 1.2rem;
+  border-radius: 14px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  text-decoration: none !important;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.otherCard:hover { transform: translateY(-3px); box-shadow: 0 10px 24px rgba(0, 0, 0, 0.1); }
+.otherEmoji { flex: none; }
+.otherName { display: block; color: var(--ifm-heading-color); font-size: 1.05rem; }
+.otherBase { display: block; font-size: 0.82rem; color: var(--ifm-color-primary); font-weight: 600; }
+.otherBlurb { display: block; font-size: 0.85rem; color: var(--ifm-color-emphasis-700); margin-top: 0.2rem; }
+
+/* CTA */
+.ctaBand {
+  padding: 4.5rem 1rem;
+  color: #fff;
+  background: linear-gradient(120deg, var(--v-accent) 0%, var(--v-accent2) 100%);
+}
+.ctaEmoji { margin-bottom: 0.5rem; }
+.ctaTitle { font-size: clamp(1.8rem, 5vw, 2.6rem); font-weight: 800; margin-bottom: 0.5rem; }
+.ctaText { font-size: 1.1rem; opacity: 0.95; margin-bottom: 1.5rem; }

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,221 @@
+// Shared metadata for per-project landing pages (src/pages/<project>.tsx),
+// rendered by src/components/ProjectLanding. Copy is sourced from each
+// project's own docs under docs/<project>/.
+
+export type ProjectStatus = 'stable' | 'beta' | 'alpha' | 'experimental' | 'internal';
+
+export type PFeature = {emoji: string; title: string; text: string};
+export type PInstall = {label: string; code: string};
+export type PShot = {src: string; alt: string};
+
+export type Project = {
+  id: string; // route slug (/<id>) + docs slug (/docs/<id>)
+  emoji: string;
+  name: string;
+  status: ProjectStatus;
+  tagline: string;
+  lede: string;
+  accent: string;
+  accent2: string;
+  repo: string;
+  docs: string; // doc path, usually /docs/<id>
+  // Optional primary CTA beyond Docs + GitHub.
+  cta?: {label: string; to: string};
+  stats?: {label: string; value: string}[];
+  features: PFeature[];
+  install?: PInstall[];
+  screenshots?: PShot[];
+};
+
+export const STATUS_LABELS: Record<ProjectStatus, string> = {
+  stable: 'Stable',
+  beta: 'Beta',
+  alpha: 'Alpha',
+  experimental: 'Experimental',
+  internal: 'Internal',
+};
+
+export const PROJECTS: Project[] = [
+  {
+    id: 'tacklebox',
+    emoji: '🛠',
+    name: 'Tacklebox',
+    status: 'stable',
+    tagline: 'A high-performance bootc orchestrator for multi-boot, updatable, deduplicated media.',
+    lede:
+      'Tacklebox provisions multi-tenant, updatable, deduplicated bootable media — USB drives, SD cards, disk images, and ISOs — from bootc OCI images. Born from superiso, it evolves static ISOs into dynamic, writable GPT disks with a unified bootloader.',
+    accent: '#b45309',
+    accent2: '#f59e0b',
+    repo: 'https://github.com/tuna-os/tacklebox',
+    docs: '/docs/tacklebox',
+    stats: [
+      {label: 'Bootloader', value: 'systemd-boot'},
+      {label: 'Dedup', value: 'shared store + ostree'},
+      {label: 'Targets', value: 'USB · disk · ISO'},
+    ],
+    features: [
+      {emoji: '🚀', title: 'Multi-boot, unified', text: 'Installs and manages systemd-boot on a unified ESP, resolving Ostree/Composefs backend conflicts.'},
+      {emoji: '🧠', title: 'Intelligent dedup', text: 'Shares one containers/storage + ostree repo across every environment on a disk — ~80%+ savings.'},
+      {emoji: '🔄', title: 'In-place updates', text: '`tacklebox update` rotates BLS entries and extracts new kernels/initrd safely, without wiping persistence.'},
+      {emoji: '💾', title: 'Modal booting', text: 'Live (ephemeral) and persistent boot entries for the same image via smart kernel-arg manipulation.'},
+      {emoji: '📂', title: 'Shared persistence', text: 'OverlayFS mounts share /home/liveuser across OSes while isolating per-desktop config (KDE vs GNOME).'},
+      {emoji: '🛡️', title: 'Integrity first', text: 'Auto-enables fs-verity to support modern container backends like Composefs.'},
+    ],
+    install: [
+      {label: 'Build a multi-boot image', code: 'sudo tacklebox build recipe.json --xz'},
+      {label: 'Provision a physical USB', code: 'sudo tacklebox build recipe.json /dev/sda'},
+      {label: 'Refresh an existing drive', code: 'sudo tacklebox update recipe.json /dev/sda'},
+    ],
+  },
+  {
+    id: 'tromso',
+    emoji: '🌋',
+    name: 'Tromsø',
+    status: 'alpha',
+    tagline: 'A BuildStream-based KDE Linux distribution, built from source with reproducible pipelines.',
+    lede:
+      'Aurora Tromsø is a BuildStream-based KDE Linux OCI/bootc image, modeled on Project Bluefin’s dakota. It builds KDE Plasma 6 on top of freedesktop-sdk and publishes a bootable OCI image — and it boots to a working Plasma 6 Wayland desktop.',
+    accent: '#b91c1c',
+    accent2: '#f97316',
+    repo: 'https://github.com/tuna-os/tromso',
+    docs: '/docs/tromso',
+    stats: [
+      {label: 'Desktop', value: 'KDE Plasma 6'},
+      {label: 'Build', value: 'BuildStream'},
+      {label: 'Base', value: 'freedesktop-sdk'},
+    ],
+    features: [
+      {emoji: '🧩', title: 'Built from source', text: 'A complete KDE desktop assembled from ~170 BuildStream elements (Qt6, Frameworks, Plasma, apps).'},
+      {emoji: '🔁', title: 'Reproducible pipelines', text: 'BuildStream gives deterministic, cacheable builds — the same inputs always yield the same image.'},
+      {emoji: '🐳', title: 'OCI + bootc native', text: 'Publishes a bootable OCI image you can run, rebase onto, or turn into installable media.'},
+      {emoji: '🧱', title: 'Two-repo model', text: 'kde-build-meta builds the KDE base (like gnome-build-meta); Tromsø layers Aurora theming and apps on top.'},
+    ],
+    install: [
+      {label: 'Build the image', code: 'git clone https://github.com/tuna-os/tromso.git\ncd tromso\njust build'},
+      {label: 'Boot a test VM', code: 'just generate-bootable-image\njust boot-vm'},
+    ],
+  },
+  {
+    id: 'tavern',
+    emoji: '🍻',
+    name: 'Tavern',
+    status: 'stable',
+    tagline: 'A modern, fast, beautiful Homebrew client for Linux — GTK 4 + Libadwaita.',
+    lede:
+      'Tavern is a premium “App Store” experience for managing your Homebrew formulae and casks, built with Python, GTK 4, and Libadwaita. Browse, search, and install with a native, responsive, dark-mode-ready interface.',
+    accent: '#a16207',
+    accent2: '#eab308',
+    repo: 'https://github.com/tuna-os/Tavern',
+    docs: '/docs/tavern',
+    stats: [
+      {label: 'Toolkit', value: 'GTK 4 · Libadwaita'},
+      {label: 'Backend', value: 'Homebrew'},
+      {label: 'Install', value: 'Flatpak · brew'},
+    ],
+    features: [
+      {emoji: '🏠', title: 'Curated browse', text: 'Discover popular and featured applications at a glance.'},
+      {emoji: '🔍', title: 'Fast search', text: 'Instant searching across thousands of formulae and casks.'},
+      {emoji: '📦', title: 'Rich package details', text: 'Descriptions, versions, dependencies, and screenshots for every package.'},
+      {emoji: '📄', title: 'Brewfile support', text: 'Open and manage .Brewfiles to bulk-install or remove entire environments.'},
+      {emoji: '⚡', title: 'Parallel tasks', text: 'Concurrent installs and removals with a global progress indicator.'},
+      {emoji: '🐧', title: 'Linux first', text: 'Smart filtering hides macOS-only casks on Linux; full dark-mode and responsive layouts.'},
+    ],
+    install: [
+      {label: 'Homebrew (macOS + Linux)', code: 'brew tap hanthor/homebrew-tap\nbrew install --cask hanthor/tap/tavern'},
+    ],
+    screenshots: [
+      {src: 'https://raw.githubusercontent.com/tuna-os/Tavern/main/data/screenshots/main-window.png', alt: 'Tavern main window'},
+      {src: 'https://raw.githubusercontent.com/tuna-os/Tavern/main/data/screenshots/search%20results.png', alt: 'Tavern search results'},
+      {src: 'https://raw.githubusercontent.com/tuna-os/Tavern/main/data/screenshots/App%20View.png', alt: 'Tavern package detail view'},
+      {src: 'https://raw.githubusercontent.com/tuna-os/Tavern/main/data/screenshots/Tap%20View.png', alt: 'Tavern taps browser'},
+    ],
+  },
+  {
+    id: 'bluefin-cli',
+    emoji: '⌨️',
+    name: 'bluefin-cli',
+    status: 'stable',
+    tagline: 'A modern CLI for shell config and dev-environment customization, with beautiful Charm TUIs.',
+    lede:
+      'bluefin-cli manages your shell configuration and development-environment tooling from one place — toggle modern shell enhancements, install curated tool bundles, apply Starship themes, and more, all through polished terminal UIs.',
+    accent: '#1d4ed8',
+    accent2: '#22d3ee',
+    repo: 'https://github.com/tuna-os/bluefin-cli',
+    docs: '/docs/bluefin-cli',
+    stats: [
+      {label: 'Language', value: 'Go'},
+      {label: 'TUI', value: 'Charm'},
+      {label: 'OS', value: 'Linux · macOS · Windows'},
+    ],
+    features: [
+      {emoji: '🎨', title: 'Interactive menu', text: 'A default TUI experience for easy navigation of every command.'},
+      {emoji: '✨', title: 'Bling', text: 'Toggle modern shell enhancements: eza, bat, ugrep, zoxide, atuin, starship.'},
+      {emoji: '📰', title: 'MOTD', text: 'A beautiful Message of the Day with system info and random tips.'},
+      {emoji: '📦', title: 'Bundle installer', text: 'Install curated tool bundles (ai, cli, fonts, k8s) from Universal Blue.'},
+      {emoji: '🖼️', title: 'Wallpapers & themes', text: 'Install wallpaper collections and browse/apply Starship prompt themes.'},
+      {emoji: '📊', title: 'Status at a glance', text: 'View your configuration and installed tools with one command.'},
+    ],
+    install: [
+      {label: 'macOS / Linux (Go)', code: 'go install github.com/hanthor/bluefin-cli@latest'},
+      {label: 'Homebrew (experimental)', code: 'brew tap ublue-os/homebrew-experimental-tap\nbrew install bluefin-cli'},
+    ],
+  },
+  {
+    id: 'xfce-linux',
+    emoji: '🖥️',
+    name: 'XFCE Linux',
+    status: 'alpha',
+    tagline: 'A lightweight XFCE Wayland desktop on an immutable bootc base, built with BuildStream.',
+    lede:
+      'XFCE Linux is an XFCE Wayland OCI image built with BuildStream — a lightweight, fast desktop experience layered on an immutable, atomically-updated base. Early-stage and evolving.',
+    accent: '#475569',
+    accent2: '#0ea5e9',
+    repo: 'https://github.com/tuna-os/xfce-linux',
+    docs: '/docs/xfce-linux',
+    stats: [
+      {label: 'Desktop', value: 'XFCE (Wayland)'},
+      {label: 'Build', value: 'BuildStream'},
+      {label: 'Status', value: 'Alpha'},
+    ],
+    features: [
+      {emoji: '🪶', title: 'Lightweight', text: 'XFCE keeps the desktop fast and out of the way — ideal for older or resource-constrained hardware.'},
+      {emoji: '🌊', title: 'Wayland', text: 'A modern Wayland session rather than legacy X11.'},
+      {emoji: '🔄', title: 'Immutable + atomic', text: 'bootc image-based updates with clean rollbacks, like the rest of the TunaOS family.'},
+      {emoji: '🧩', title: 'BuildStream pipeline', text: 'Reproducible, cacheable builds from source.'},
+    ],
+  },
+  {
+    id: 'tunaos',
+    emoji: '🐟',
+    name: 'TunaOS',
+    status: 'stable',
+    tagline: 'Cloud-native Enterprise Linux desktop images built with bootc.',
+    lede:
+      'TunaOS is a curated collection of bootc-based desktop operating systems that bring a modern desktop experience to Enterprise Linux — stable, immutable, and up-to-date. GNOME, KDE, COSMIC, and Niri on AlmaLinux, CentOS Stream, and Fedora.',
+    accent: '#0056b3',
+    accent2: '#0ea5e9',
+    repo: 'https://github.com/tuna-os/tunaOS',
+    docs: '/docs/tunaos',
+    cta: {label: 'Download ISOs 📦', to: '/download'},
+    stats: [
+      {label: 'Variants', value: '4 bases'},
+      {label: 'Desktops', value: 'GNOME · KDE · COSMIC · Niri'},
+      {label: 'Built on', value: 'bootc'},
+    ],
+    features: [
+      {emoji: '🖥️', title: 'Modern desktops', text: 'GNOME, KDE Plasma, COSMIC, and Niri — your choice, on Enterprise Linux.'},
+      {emoji: '✨', title: 'Latest GNOME', text: 'We backport the latest desktop features instead of leaving you on a 3-year-old GNOME.'},
+      {emoji: '🍺', title: 'Homebrew baked in', text: 'All your CLI apps and fonts are a `brew` command away.'},
+      {emoji: '📦', title: 'Flathub by default', text: 'Full Flathub access out of the box.'},
+      {emoji: '🔧', title: 'HWE option', text: 'Hardware Enablement kernel for newer hardware.'},
+      {emoji: '🎮', title: 'NVIDIA option', text: 'NVIDIA drivers and CUDA for graphics and AI workflows.'},
+    ],
+    install: [
+      {label: 'Rebase an existing bootc system', code: 'sudo bootc switch ghcr.io/tuna-os/albacore:gnome'},
+    ],
+  },
+];
+
+export function getProject(id: string): Project | undefined {
+  return PROJECTS.find((p) => p.id === id);
+}

--- a/src/data/variants.ts
+++ b/src/data/variants.ts
@@ -1,0 +1,224 @@
+// Shared variant metadata. Drives the homepage line-up, the per-variant
+// landing pages (src/pages/<variant>.tsx), and the navbar/footer links.
+// One source of truth so the marketing copy never drifts between surfaces.
+
+export type Desktop = {
+  emoji: string;
+  name: string;
+  tag: string; // image tag suffix, e.g. "gnome", "kde"
+  blurb: string;
+};
+
+export type Feature = {
+  emoji: string;
+  title: string;
+  text: string;
+};
+
+export type Flavor = {
+  name: string;
+  image: string; // full ghcr ref
+  note?: string;
+};
+
+export type Variant = {
+  id: string; // route slug + image repo, e.g. "yellowfin"
+  emoji: string;
+  name: string;
+  base: string;
+  baseUrl: string;
+  recommended?: boolean;
+  // Short one-liner used on cards.
+  blurb: string;
+  // Longer hero paragraph.
+  lede: string;
+  // Accent colours for the hero gradient + buttons.
+  accent: string;
+  accent2: string;
+  // Quick-stat chips shown under the hero title.
+  stats: {label: string; value: string}[];
+  desktops: Desktop[];
+  features: Feature[];
+  flavors: Flavor[];
+  // Whether grouped/flagship live ISOs are published for this variant.
+  hasIsos: boolean;
+};
+
+const ALL_DESKTOPS: Desktop[] = [
+  {emoji: '🖥️', name: 'GNOME', tag: 'gnome', blurb: 'The polished default — latest GNOME, backported to Enterprise Linux.'},
+  {emoji: '✨', name: 'GNOME 50', tag: 'gnome50', blurb: 'The newest GNOME stack, riding the same base.'},
+  {emoji: '🌊', name: 'KDE Plasma', tag: 'kde', blurb: 'Endlessly customizable, feature-rich Plasma desktop.'},
+  {emoji: '🚀', name: 'COSMIC', tag: 'cosmic', blurb: "System76's Rust-built next-gen desktop."},
+  {emoji: '⚡', name: 'Niri', tag: 'niri', blurb: 'A scrollable-tiling Wayland compositor for keyboard-driven flow.'},
+];
+
+const HOMEBREW: Feature = {
+  emoji: '🍺',
+  title: 'Homebrew baked in',
+  text: 'Thousands of CLI tools and fonts a `brew install` away — no layering, no rebuilds.',
+};
+const FLATHUB: Feature = {
+  emoji: '📦',
+  title: 'Flathub by default',
+  text: 'Full Flathub access out of the box. Install any Flatpak on the net, instantly.',
+};
+const BOOTC: Feature = {
+  emoji: '🔄',
+  title: 'Atomic & rollback-safe',
+  text: 'Built on bootc: image-based updates that apply in one transaction and roll back just as cleanly.',
+};
+const NVIDIA: Feature = {
+  emoji: '🎮',
+  title: 'NVIDIA + CUDA option',
+  text: 'A dedicated -nvidia flavor ships the proprietary driver and CUDA for gaming and AI workloads.',
+};
+const HWE: Feature = {
+  emoji: '🔧',
+  title: 'Hardware Enablement',
+  text: 'An -hwe kernel stack for newer laptops and desktops, layered on the same userspace.',
+};
+
+export const VARIANTS: Variant[] = [
+  {
+    id: 'albacore',
+    emoji: '🐟',
+    name: 'Albacore',
+    base: 'AlmaLinux 10',
+    baseUrl: 'https://almalinux.org',
+    recommended: true,
+    blurb: '10-year support cycle. The rock-solid daily driver for work.',
+    lede:
+      'Albacore is the flagship — a cloud-native desktop on AlmaLinux 10 with a full decade of support behind it. The variant you install on the machine you depend on every day.',
+    accent: '#0b6e4f',
+    accent2: '#0ea5e9',
+    stats: [
+      {label: 'Support', value: '10 years'},
+      {label: 'Cadence', value: 'Enterprise-stable'},
+      {label: 'Arch', value: 'x86_64 · aarch64'},
+    ],
+    desktops: ALL_DESKTOPS,
+    features: [BOOTC, HOMEBREW, FLATHUB, HWE, NVIDIA, {
+      emoji: '🛡️',
+      title: 'Enterprise stability',
+      text: 'AlmaLinux 10 is a 1:1 RHEL-compatible base with a 10-year lifecycle — boring in the best way.',
+    }],
+    flavors: [
+      {name: 'GNOME', image: 'ghcr.io/tuna-os/albacore:gnome', note: 'Live ISO published'},
+      {name: 'GNOME (HWE)', image: 'ghcr.io/tuna-os/albacore:gnome-hwe', note: 'Live ISO published'},
+      {name: 'GNOME 50', image: 'ghcr.io/tuna-os/albacore:gnome50'},
+      {name: 'KDE Plasma', image: 'ghcr.io/tuna-os/albacore:kde'},
+      {name: 'COSMIC', image: 'ghcr.io/tuna-os/albacore:cosmic'},
+      {name: 'Niri', image: 'ghcr.io/tuna-os/albacore:niri'},
+      {name: 'GNOME (NVIDIA)', image: 'ghcr.io/tuna-os/albacore:gnome-nvidia'},
+    ],
+    hasIsos: true,
+  },
+  {
+    id: 'yellowfin',
+    emoji: '🐠',
+    name: 'Yellowfin',
+    base: 'AlmaLinux Kitten 10',
+    baseUrl: 'https://almalinux.org/blog/2024-11-20-introducing-almalinux-kitten-10/',
+    blurb: 'Newer packages on a near-enterprise base. The developer pick.',
+    lede:
+      "Yellowfin tracks AlmaLinux Kitten — the upstream-tracking branch of AlmaLinux. Newer packages and features land here first, on a base that's still almost enterprise-stable. The lead developer's daily driver.",
+    accent: '#d97706',
+    accent2: '#f59e0b',
+    stats: [
+      {label: 'Base', value: 'Kitten 10'},
+      {label: 'Cadence', value: 'Fresh + stable'},
+      {label: 'Microarch', value: 'x86_64_v2 builds'},
+    ],
+    desktops: ALL_DESKTOPS,
+    features: [BOOTC, HOMEBREW, FLATHUB, HWE, NVIDIA, {
+      emoji: '🐱',
+      title: 'Kitten freshness',
+      text: 'Newer GNOME, kernels, and toolchains before they reach stable EL — without leaving the EL ecosystem.',
+    }],
+    flavors: [
+      {name: 'GNOME', image: 'ghcr.io/tuna-os/yellowfin:gnome', note: 'Live ISO published'},
+      {name: 'GNOME (HWE)', image: 'ghcr.io/tuna-os/yellowfin:gnome-hwe', note: 'Live ISO published'},
+      {name: 'GNOME 50', image: 'ghcr.io/tuna-os/yellowfin:gnome50'},
+      {name: 'KDE Plasma', image: 'ghcr.io/tuna-os/yellowfin:kde'},
+      {name: 'COSMIC', image: 'ghcr.io/tuna-os/yellowfin:cosmic'},
+      {name: 'Niri', image: 'ghcr.io/tuna-os/yellowfin:niri'},
+      {name: 'GNOME (NVIDIA)', image: 'ghcr.io/tuna-os/yellowfin:gnome-nvidia'},
+    ],
+    hasIsos: true,
+  },
+  {
+    id: 'skipjack',
+    emoji: '🍣',
+    name: 'Skipjack',
+    base: 'CentOS Stream 10',
+    baseUrl: 'https://www.centos.org/stream/',
+    blurb: 'Upstream-tracking — a preview of where Enterprise Linux is headed.',
+    lede:
+      'Skipjack rides CentOS Stream 10, the rolling preview of the next RHEL. It’s where you see what’s coming to Enterprise Linux next — ideal for testing and contributing upstream.',
+    accent: '#7c3aed',
+    accent2: '#a855f7',
+    stats: [
+      {label: 'Base', value: 'CentOS Stream 10'},
+      {label: 'Cadence', value: 'Rolling preview'},
+      {label: 'Role', value: 'Next-RHEL testing'},
+    ],
+    desktops: ALL_DESKTOPS,
+    features: [BOOTC, HOMEBREW, FLATHUB, HWE, {
+      emoji: '🔭',
+      title: 'See what’s next',
+      text: 'CentOS Stream is the upstream of RHEL — Skipjack previews the Enterprise Linux of tomorrow.',
+    }, {
+      emoji: '🤝',
+      title: 'Upstream-friendly',
+      text: 'The natural place to reproduce, file, and fix issues that flow into the whole EL ecosystem.',
+    }],
+    flavors: [
+      {name: 'GNOME', image: 'ghcr.io/tuna-os/skipjack:gnome'},
+      {name: 'GNOME 50', image: 'ghcr.io/tuna-os/skipjack:gnome50'},
+      {name: 'KDE Plasma', image: 'ghcr.io/tuna-os/skipjack:kde'},
+      {name: 'COSMIC', image: 'ghcr.io/tuna-os/skipjack:cosmic'},
+      {name: 'Niri', image: 'ghcr.io/tuna-os/skipjack:niri'},
+    ],
+    hasIsos: true,
+  },
+  {
+    id: 'bonito',
+    emoji: '🎣',
+    name: 'Bonito',
+    base: 'Fedora 44',
+    baseUrl: 'https://fedoraproject.org',
+    blurb: 'Bleeding-edge packages and the very latest kernel.',
+    lede:
+      'Bonito is built on Fedora 44 — the freshest kernels, GNOME, and toolchains in the line-up. For the largest desktop Linux ecosystem and the people who want the latest of everything.',
+    accent: '#2563eb',
+    accent2: '#38bdf8',
+    stats: [
+      {label: 'Base', value: 'Fedora 44'},
+      {label: 'Cadence', value: 'Bleeding edge'},
+      {label: 'Kernel', value: 'Latest mainline'},
+    ],
+    desktops: ALL_DESKTOPS.filter((d) => d.tag !== 'gnome50'),
+    features: [BOOTC, HOMEBREW, FLATHUB, NVIDIA, {
+      emoji: '🚀',
+      title: 'Freshest of everything',
+      text: 'Fedora ships the latest kernel, GNOME, and Mesa — Bonito brings that to an immutable bootc desktop.',
+    }, {
+      emoji: '🌍',
+      title: 'Largest ecosystem',
+      text: 'Fedora is the most widely used desktop Linux base — broad hardware and software coverage out of the box.',
+    }],
+    flavors: [
+      {name: 'GNOME', image: 'ghcr.io/tuna-os/bonito:gnome'},
+      {name: 'GNOME (HWE)', image: 'ghcr.io/tuna-os/bonito:gnome-hwe'},
+      {name: 'KDE Plasma', image: 'ghcr.io/tuna-os/bonito:kde'},
+      {name: 'COSMIC', image: 'ghcr.io/tuna-os/bonito:cosmic'},
+      {name: 'Niri', image: 'ghcr.io/tuna-os/bonito:niri'},
+      {name: 'GNOME (NVIDIA)', image: 'ghcr.io/tuna-os/bonito:gnome-nvidia'},
+    ],
+    hasIsos: false,
+  },
+];
+
+export function getVariant(id: string): Variant | undefined {
+  return VARIANTS.find((v) => v.id === id);
+}

--- a/src/pages/albacore.tsx
+++ b/src/pages/albacore.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import VariantLanding from '@site/src/components/VariantLanding';
+import {getVariant} from '@site/src/data/variants';
+
+export default function AlbacorePage(): ReactNode {
+  return <VariantLanding variant={getVariant('albacore')!} />;
+}

--- a/src/pages/bluefin-cli.tsx
+++ b/src/pages/bluefin-cli.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import ProjectLanding from '@site/src/components/ProjectLanding';
+import {getProject} from '@site/src/data/projects';
+
+export default function BluefinCliPage(): ReactNode {
+  return <ProjectLanding project={getProject('bluefin-cli')!} />;
+}

--- a/src/pages/bonito.tsx
+++ b/src/pages/bonito.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import VariantLanding from '@site/src/components/VariantLanding';
+import {getVariant} from '@site/src/data/variants';
+
+export default function BonitoPage(): ReactNode {
+  return <VariantLanding variant={getVariant('bonito')!} />;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -145,12 +145,12 @@ function DocsBand(): ReactNode {
 
 function ProjectsBand(): ReactNode {
   const featured = [
-    {emoji: '🐟', name: 'TunaOS', desc: 'Desktop images', to: '/docs/tunaos'},
-    {emoji: '🧰', name: 'Tacklebox', desc: 'ISO & USB builder', to: '/docs/tacklebox'},
-    {emoji: '🌋', name: 'Tromsø', desc: 'KDE Linux', to: '/docs/tromso'},
-    {emoji: '🖥️', name: 'XFCE Linux', desc: 'XFCE desktop', to: '/docs/xfce-linux'},
-    {emoji: '🍻', name: 'Tavern', desc: 'Homebrew GUI', to: '/docs/tavern'},
-    {emoji: '⌨️', name: 'bluefin-cli', desc: 'Shell CLI', to: '/docs/bluefin-cli'},
+    {emoji: '🐟', name: 'TunaOS', desc: 'Desktop images', to: '/tunaos'},
+    {emoji: '🧰', name: 'Tacklebox', desc: 'ISO & USB builder', to: '/tacklebox'},
+    {emoji: '🌋', name: 'Tromsø', desc: 'KDE Linux', to: '/tromso'},
+    {emoji: '🖥️', name: 'XFCE Linux', desc: 'XFCE desktop', to: '/xfce-linux'},
+    {emoji: '🍻', name: 'Tavern', desc: 'Homebrew GUI', to: '/tavern'},
+    {emoji: '⌨️', name: 'bluefin-cli', desc: 'Shell CLI', to: '/bluefin-cli'},
   ];
   return (
     <section className={clsx(styles.section)}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ const VARIANTS = [
     name: 'Albacore',
     base: 'AlmaLinux 10',
     blurb: '10-year support cycle. The rock-solid daily driver for work.',
-    to: '/docs/albacore',
+    to: '/albacore',
     flagship: true,
   },
   {
@@ -23,21 +23,21 @@ const VARIANTS = [
     name: 'Yellowfin',
     base: 'AlmaLinux Kitten',
     blurb: 'Newer packages on a near-enterprise base. The developer pick.',
-    to: '/docs/yellowfin',
+    to: '/yellowfin',
   },
   {
     emoji: '🍣',
     name: 'Skipjack',
     base: 'CentOS Stream 10',
     blurb: 'Upstream-tracking — a preview of where Enterprise Linux is headed.',
-    to: '/docs/skipjack',
+    to: '/skipjack',
   },
   {
     emoji: '🎣',
     name: 'Bonito',
     base: 'Fedora 44',
     blurb: 'Bleeding-edge packages and the very latest kernel.',
-    to: '/docs/bonito',
+    to: '/bonito',
   },
 ];
 

--- a/src/pages/skipjack.tsx
+++ b/src/pages/skipjack.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import VariantLanding from '@site/src/components/VariantLanding';
+import {getVariant} from '@site/src/data/variants';
+
+export default function SkipjackPage(): ReactNode {
+  return <VariantLanding variant={getVariant('skipjack')!} />;
+}

--- a/src/pages/tacklebox.tsx
+++ b/src/pages/tacklebox.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import ProjectLanding from '@site/src/components/ProjectLanding';
+import {getProject} from '@site/src/data/projects';
+
+export default function TackleboxPage(): ReactNode {
+  return <ProjectLanding project={getProject('tacklebox')!} />;
+}

--- a/src/pages/tavern.tsx
+++ b/src/pages/tavern.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import ProjectLanding from '@site/src/components/ProjectLanding';
+import {getProject} from '@site/src/data/projects';
+
+export default function TavernPage(): ReactNode {
+  return <ProjectLanding project={getProject('tavern')!} />;
+}

--- a/src/pages/tromso.tsx
+++ b/src/pages/tromso.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import ProjectLanding from '@site/src/components/ProjectLanding';
+import {getProject} from '@site/src/data/projects';
+
+export default function TromsoPage(): ReactNode {
+  return <ProjectLanding project={getProject('tromso')!} />;
+}

--- a/src/pages/tunaos.tsx
+++ b/src/pages/tunaos.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import ProjectLanding from '@site/src/components/ProjectLanding';
+import {getProject} from '@site/src/data/projects';
+
+export default function TunaosProjectPage(): ReactNode {
+  return <ProjectLanding project={getProject('tunaos')!} />;
+}

--- a/src/pages/xfce-linux.tsx
+++ b/src/pages/xfce-linux.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import ProjectLanding from '@site/src/components/ProjectLanding';
+import {getProject} from '@site/src/data/projects';
+
+export default function XfceLinuxPage(): ReactNode {
+  return <ProjectLanding project={getProject('xfce-linux')!} />;
+}

--- a/src/pages/yellowfin.tsx
+++ b/src/pages/yellowfin.tsx
@@ -1,0 +1,7 @@
+import type {ReactNode} from 'react';
+import VariantLanding from '@site/src/components/VariantLanding';
+import {getVariant} from '@site/src/data/variants';
+
+export default function YellowfinPage(): ReactNode {
+  return <VariantLanding variant={getVariant('yellowfin')!} />;
+}


### PR DESCRIPTION
Gives every TunaOS **variant** and **project** a cool, custom landing page at its own route — instead of dropping visitors into a plain markdown doc — showcasing each with graphics, accent-themed heroes, and real content.

## Variant pages — `/albacore` `/yellowfin` `/skipjack` `/bonito`
- Accent-gradient hero (per-variant colours), floating animated fish emoji, base-distro link, quick-stat chips, Download/Docs CTAs.
- "One base, every desktop" desktop showcase · "Why <variant>" feature grid · images & flavors table with a copy-paste `bootc switch` · cross-links + closing CTA.
- Navbar gains a **Variants** dropdown; homepage cards + footer point at the new routes. Bonito correctly omits the EL-only GNOME 50.

## Project pages — `/tacklebox` `/tromso` `/tavern` `/bluefin-cli` `/xfce-linux` `/tunaos`
- Accent-gradient hero with status badge, tagline, stat chips, Docs + GitHub (+ optional Download) CTAs.
- Features grid · optional "get started" install snippets · **real screenshots** (Tavern pulls its GTK screenshots straight from the Tavern repo) · cross-links to other projects.
- The `/projects` grid and the homepage "More from TunaOS" band now deep-link to these landing pages (COPR stays on its doc page).

## How it's built
- **`src/data/variants.ts`** and **`src/data/projects.ts`** — single sources of truth; project copy is sourced from each project's own `docs/<project>/`.
- **`src/components/VariantLanding`** and **`src/components/ProjectLanding`** — reusable, data-driven components; accent colours injected as CSS custom properties so one component themes them all.
- Thin per-route pages under `src/pages/`.

## Verification
`npm run build` succeeds; all ten landing pages render with the expected heroes, sections, and (for Tavern) embedded screenshots. The pre-existing `ImagePicker` typecheck warnings, the duplicate `/docs/xfce-linux` route, and the tavern `CLAUDE.md` broken-link warning are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)