### PR TITLE
feat: doc⇄landing cross-links, sidebar showcase, auto desktop screenshots

### DIFF
--- a/docs/albacore.md
+++ b/docs/albacore.md
@@ -4,6 +4,10 @@ sidebar_position: 2
 
 # Albacore (AlmaLinux)
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Albacore overview →](/albacore)** landing page.
+:::
+
 **Based on:** [AlmaLinux 10.0](https://almalinux.org/blog/2025-05-27-welcoming-almalinux-10/)
 
 Albacore is the flagship stable variant of TunaOS, providing a rock-solid enterprise-grade desktop experience built on the AlmaLinux foundation.

--- a/docs/bluefin-cli/index.md
+++ b/docs/bluefin-cli/index.md
@@ -4,6 +4,10 @@ sidebar_label: "bluefin-cli"
 status: stable
 ---
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[bluefin-cli overview →](/bluefin-cli)** landing page.
+:::
+
 A powerful, modern CLI tool for managing shell configuration and development environment customization. Built with beautiful TUIs using [Charm](https://charm.sh/) libraries.
 
 ## ✨ Features

--- a/docs/bonito.md
+++ b/docs/bonito.md
@@ -4,6 +4,10 @@ sidebar_position: 5
 
 # Bonito (Fedora)
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Bonito overview →](/bonito)** landing page.
+:::
+
 **Based on:** [Fedora 42](https://fedoraproject.org/)
 
 Bonito is the most experimental variant of TunaOS, based on Fedora 42. It provides the latest packages, kernels, and desktop features ahead of any Enterprise Linux release.

--- a/docs/skipjack.md
+++ b/docs/skipjack.md
@@ -4,6 +4,10 @@ sidebar_position: 4
 
 # Skipjack (CentOS)
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Skipjack overview →](/skipjack)** landing page.
+:::
+
 **Based on:** [CentOS Stream 10](https://www.centos.org/centos-stream-10/)
 
 Skipjack is the upstream-tracking variant of TunaOS based on CentOS Stream 10. It serves as a testing ground for features that will eventually land in RHEL and AlmaLinux.

--- a/docs/tacklebox/index.md
+++ b/docs/tacklebox/index.md
@@ -4,6 +4,10 @@ sidebar_label: "Tacklebox"
 status: stable
 ---
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Tacklebox overview →](/tacklebox)** landing page.
+:::
+
 **Tacklebox** is a high-performance orchestrator for `bootc` that provisions multi-tenant, updatable, and deduplicated bootable media (USB drives, SD cards, or raw disk images).
 
 Born from the `superiso` project, Tacklebox evolves the concept from static ISOs to dynamic, writable GPT disks with a unified bootloader.

--- a/docs/tavern/index.md
+++ b/docs/tavern/index.md
@@ -4,6 +4,10 @@ sidebar_label: "Tavern"
 status: stable
 ---
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Tavern overview →](/tavern)** landing page.
+:::
+
 Tavern is a modern, fast, and beautiful Homebrew client for Linux, built with **Python**, **GTK 4**, and **Libadwaita**. It provides a premium "App Store" experience for managing your Homebrew formulae and casks.
 
 ### Quick Install

--- a/docs/tromso/index.md
+++ b/docs/tromso/index.md
@@ -4,6 +4,10 @@ sidebar_label: "Tromsø"
 status: alpha
 ---
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Tromsø overview →](/tromso)** landing page.
+:::
+
 > ⚠️ **Alpha** — early development. Not production-ready. APIs and behaviour may change without notice.
 
 **Aurora Tromso** is a BuildStream-based KDE Linux OCI/bootc image, modeled on Project Bluefin's

--- a/docs/tunaos/index.md
+++ b/docs/tunaos/index.md
@@ -4,6 +4,10 @@ sidebar_label: "TunaOS"
 status: stable
 ---
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[TunaOS overview →](/tunaos)** landing page.
+:::
+
 
 <div>
 ![]

--- a/docs/xfce-linux/index.md
+++ b/docs/xfce-linux/index.md
@@ -4,6 +4,10 @@ sidebar_label: "XFCE Linux"
 status: alpha
 ---
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[XFCE Linux overview →](/xfce-linux)** landing page.
+:::
+
 > ⚠️ **Alpha** — early development. Not production-ready. APIs and behaviour may change without notice.
 
 # Ready for GitHub Actions

--- a/docs/yellowfin.md
+++ b/docs/yellowfin.md
@@ -4,6 +4,10 @@ sidebar_position: 3
 
 # Yellowfin (AlmaLinux Kitten)
 
+:::tip[Visual overview]
+Prefer a visual tour? See the **[Yellowfin overview →](/yellowfin)** landing page.
+:::
+
 **Based on:** [AlmaLinux Kitten 10](https://almalinux.org/blog/2024-11-20-introducing-almalinux-kitten-10/)
 
 Yellowfin is the "developer's daily drive" variant of TunaOS. It tracks AlmaLinux Kitten, which is the upstream-tracking, more experimental branch of AlmaLinux. This variant is closest to the upstream Bluefin LTS experience.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -6,7 +6,20 @@ const sidebars: SidebarsConfig = {
     'installation',
     'installer',
     'system-requirements',
-    {type: 'category', label: 'Variants', items: ['albacore', 'yellowfin', 'bonito', 'skipjack']},
+    {
+      type: 'category',
+      label: '🐟 Variants',
+      collapsed: false,
+      // Showcase: the rich, visual landing pages (custom React pages), with the
+      // detailed per-variant reference docs nested beneath.
+      items: [
+        {type: 'link', label: 'Albacore — AlmaLinux 10', href: '/albacore'},
+        {type: 'link', label: 'Yellowfin — AlmaLinux Kitten', href: '/yellowfin'},
+        {type: 'link', label: 'Skipjack — CentOS Stream 10', href: '/skipjack'},
+        {type: 'link', label: 'Bonito — Fedora 44', href: '/bonito'},
+        {type: 'category', label: 'Reference docs', collapsed: true, items: ['albacore', 'yellowfin', 'bonito', 'skipjack']},
+      ],
+    },
     'bootc-resources',
     {type: 'category', label: 'TunaOS', link: {type: 'doc', id: 'tunaos/index'}, items: ['tunaos/ROADMAP', 'tunaos/CONTRIBUTING', 'tunaos/SECURITY', {type: 'category', label: 'Developer Guide', collapsible: true, collapsed: true, items: ['tunaos/introduction', 'tunaos/building', 'tunaos/live-iso-generation', 'tunaos/ci-cd', 'tunaos/troubleshooting']}]},
     {type: 'category', label: 'Tacklebox', link: {type: 'doc', id: 'tacklebox/index'}, items: ['tacklebox/ARCHITECTURE', 'tacklebox/github-iso-setup', 'tacklebox/TODO']},

--- a/src/components/DesktopScreenshots/index.tsx
+++ b/src/components/DesktopScreenshots/index.tsx
@@ -1,0 +1,73 @@
+import {useState} from 'react';
+import type {ReactNode} from 'react';
+import Heading from '@theme/Heading';
+import type {Desktop} from '@site/src/data/variants';
+
+import styles from './styles.module.css';
+
+// Public base for the booted-desktop screenshots produced weekly by the
+// tunaOS `weekly-qcow2-screenshots.yml` workflow (variant × desktop, booted in
+// QEMU and screendumped). The workflow uploads them to R2 at
+// screenshots/<variant>-<flavor>-latest.png, served from download.tunaos.org.
+const SHOT_BASE = 'https://download.tunaos.org/screenshots';
+
+function shotUrl(variant: string, tag: string): string {
+  return `${SHOT_BASE}/${variant}-${tag}-latest.png`;
+}
+
+// Renders the real, auto-captured desktop screenshots for a variant. Any combo
+// that isn't published yet (404s) is hidden client-side; if none load, the
+// whole section disappears — so the page degrades gracefully whether or not the
+// weekly run has populated R2.
+export default function DesktopScreenshots({
+  variant,
+  desktops,
+}: {
+  variant: string;
+  desktops: Desktop[];
+}): ReactNode {
+  const [failed, setFailed] = useState<Record<string, boolean>>({});
+  const visible = desktops.filter((d) => !failed[d.tag]);
+
+  if (visible.length === 0) {
+    // Still render the (hidden) <img>s so a late-arriving screenshot can flip
+    // the section back on without a reload — but show no heading/empty frame.
+    return (
+      <div className={styles.probe} aria-hidden>
+        {desktops.map((d) => (
+          <img
+            key={d.tag}
+            src={shotUrl(variant, d.tag)}
+            alt=""
+            onError={() => setFailed((f) => ({...f, [d.tag]: true}))}
+            onLoad={() => setFailed((f) => (f[d.tag] ? {...f, [d.tag]: false} : f))}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.head}>
+          <Heading as="h2">See the desktops</Heading>
+          <p>Real screenshots, captured automatically each week by booting every desktop in a VM.</p>
+        </div>
+        <div className={styles.grid}>
+          {visible.map((d) => (
+            <figure key={d.tag} className={styles.shot}>
+              <img
+                src={shotUrl(variant, d.tag)}
+                alt={`${d.name} desktop on ${variant}`}
+                loading="lazy"
+                onError={() => setFailed((f) => ({...f, [d.tag]: true}))}
+              />
+              <figcaption>{d.name}</figcaption>
+            </figure>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/DesktopScreenshots/styles.module.css
+++ b/src/components/DesktopScreenshots/styles.module.css
@@ -1,0 +1,53 @@
+.section {
+  padding: 4rem 1rem;
+}
+
+.head {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 2.5rem;
+}
+.head h2 {
+  font-size: clamp(1.7rem, 4vw, 2.3rem);
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+}
+.head p {
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.shot {
+  margin: 0;
+}
+.shot img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  display: block;
+  background: var(--ifm-color-emphasis-100);
+}
+.shot figcaption {
+  margin-top: 0.6rem;
+  text-align: center;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-800);
+}
+
+/* Off-screen probe used to detect late-arriving screenshots without layout. */
+.probe {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}

--- a/src/components/ProjectLanding/index.tsx
+++ b/src/components/ProjectLanding/index.tsx
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import AnimatedEmoji from '@site/src/components/AnimatedEmoji';
-import {PROJECTS, STATUS_LABELS, type Project} from '@site/src/data/projects';
+import {PROJECTS, STATUS_LABELS, BUILDSTREAM_UPSTREAMS, type Project} from '@site/src/data/projects';
 
 import styles from './styles.module.css';
 
@@ -122,6 +122,35 @@ function Install({project}: {project: Project}): ReactNode {
   );
 }
 
+function BuildStreamFamily({project}: {project: Project}): ReactNode {
+  if (!project.buildstream) return null;
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.sectionHead}>
+          <Heading as="h2">Part of the BuildStream desktop family</Heading>
+          <p>
+            {project.name} builds a complete desktop from source on freedesktop-sdk with
+            reproducible pipelines — the same lineage as GNOME OS. It's associated with these
+            upstream BuildStream desktop projects:
+          </p>
+        </div>
+        <div className={styles.otherGrid}>
+          {BUILDSTREAM_UPSTREAMS.map((u) => (
+            <a key={u.url} href={u.url} className={styles.otherCard}>
+              <span className={styles.bsDesktop}>{u.desktop}</span>
+              <span>
+                <strong className={styles.otherName}>{u.name} ↗</strong>
+                <span className={styles.otherTagline}>{u.note}</span>
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function MoreProjects({project}: {project: Project}): ReactNode {
   const others = PROJECTS.filter((p) => p.id !== project.id);
   return (
@@ -159,6 +188,7 @@ export default function ProjectLanding({project}: {project: Project}): ReactNode
         <Screenshots project={project} />
         <Features project={project} />
         <Install project={project} />
+        <BuildStreamFamily project={project} />
         <MoreProjects project={project} />
       </main>
     </Layout>

--- a/src/components/ProjectLanding/styles.module.css
+++ b/src/components/ProjectLanding/styles.module.css
@@ -132,3 +132,18 @@
 .otherEmoji { flex: none; }
 .otherName { display: block; color: var(--ifm-heading-color); font-size: 1.05rem; }
 .otherTagline { display: block; font-size: 0.85rem; color: var(--ifm-color-emphasis-700); margin-top: 0.2rem; }
+
+/* BuildStream family — desktop label badge */
+.bsDesktop {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  padding: 0.3rem 0.55rem;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(120deg, var(--p-accent, #2563eb), var(--p-accent2, #38bdf8));
+}

--- a/src/components/VariantLanding/index.tsx
+++ b/src/components/VariantLanding/index.tsx
@@ -4,6 +4,7 @@ import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import AnimatedEmoji from '@site/src/components/AnimatedEmoji';
+import DesktopScreenshots from '@site/src/components/DesktopScreenshots';
 import {VARIANTS, type Variant} from '@site/src/data/variants';
 
 import styles from './styles.module.css';
@@ -190,6 +191,7 @@ export default function VariantLanding({variant}: {variant: Variant}): ReactNode
       <Hero variant={variant} />
       <main>
         <Desktops variant={variant} />
+        <DesktopScreenshots variant={variant.id} desktops={variant.desktops} />
         <Features variant={variant} />
         <Flavors variant={variant} />
         <OtherVariants variant={variant} />

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -25,6 +25,9 @@ export type Project = {
   features: PFeature[];
   install?: PInstall[];
   screenshots?: PShot[];
+  // Built with BuildStream from source (vs. the bootc/Containerfile images).
+  // Flags the project as part of the BuildStream desktop family below.
+  buildstream?: boolean;
 };
 
 export const STATUS_LABELS: Record<ProjectStatus, string> = {
@@ -34,6 +37,31 @@ export const STATUS_LABELS: Record<ProjectStatus, string> = {
   experimental: 'Experimental',
   internal: 'Internal',
 };
+
+// The wider BuildStream "desktop from source" ecosystem that TunaOS's
+// BuildStream images (Tromsø/KDE, XFCE Linux) are modeled on and associated
+// with. Each builds a complete desktop on freedesktop-sdk with reproducible
+// pipelines — the same lineage as GNOME OS.
+export const BUILDSTREAM_UPSTREAMS: {desktop: string; name: string; url: string; note: string}[] = [
+  {
+    desktop: 'GNOME',
+    name: 'Dakota (Project Bluefin)',
+    url: 'https://projectbluefin.io/dakota/',
+    note: 'The BuildStream for Bluefin — the reference TunaOS Tromsø is modeled on.',
+  },
+  {
+    desktop: 'Niri',
+    name: 'zirconium-hawaii',
+    url: 'https://github.com/zirconium-dev/zirconium-hawaii/tree/stable',
+    note: 'Opinionated Niri bootc image built on freedesktop-sdk (a.k.a. Niri OS).',
+  },
+  {
+    desktop: 'KDE',
+    name: 'tuna-os/kde-build-meta',
+    url: 'https://github.com/tuna-os/tromso',
+    note: 'The KDE .bst elements that Tromsø builds on — the KDE analogue of gnome-build-meta.',
+  },
+];
 
 export const PROJECTS: Project[] = [
   {
@@ -79,6 +107,7 @@ export const PROJECTS: Project[] = [
     accent2: '#f97316',
     repo: 'https://github.com/tuna-os/tromso',
     docs: '/docs/tromso',
+    buildstream: true,
     stats: [
       {label: 'Desktop', value: 'KDE Plasma 6'},
       {label: 'Build', value: 'BuildStream'},
@@ -172,6 +201,7 @@ export const PROJECTS: Project[] = [
     accent2: '#0ea5e9',
     repo: 'https://github.com/tuna-os/xfce-linux',
     docs: '/docs/xfce-linux',
+    buildstream: true,
     stats: [
       {label: 'Desktop', value: 'XFCE (Wayland)'},
       {label: 'Build', value: 'BuildStream'},

--- a/src/pages/projects.module.css
+++ b/src/pages/projects.module.css
@@ -18,3 +18,66 @@
   line-height: 1.6;
   opacity: 0.9;
 }
+
+/* ── BuildStream desktop family band ── */
+.bsFamily {
+  margin-top: 3rem;
+  padding: 2rem;
+  border-radius: 18px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-color-emphasis-100);
+}
+.bsTitle {
+  font-size: clamp(1.4rem, 3.5vw, 1.9rem);
+  margin: 0 0 0.5rem;
+}
+.bsLede {
+  max-width: 760px;
+  color: var(--ifm-color-emphasis-800);
+  line-height: 1.6;
+  margin: 0 0 1.5rem;
+}
+.bsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.bsCard {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 1.1rem;
+  border-radius: 14px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  text-decoration: none !important;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.bsCard:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.1);
+}
+.bsBadge {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 54px;
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(120deg, var(--ifm-color-primary), #38bdf8);
+}
+.bsName {
+  display: block;
+  color: var(--ifm-heading-color);
+  font-size: 1rem;
+}
+.bsNote {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-top: 0.2rem;
+}

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -2,8 +2,37 @@ import type {ReactNode} from 'react';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import ProjectCards from '@site/src/components/ProjectCards';
+import {BUILDSTREAM_UPSTREAMS} from '@site/src/data/projects';
 
 import styles from './projects.module.css';
+
+function BuildStreamFamily(): ReactNode {
+  return (
+    <section className={styles.bsFamily}>
+      <Heading as="h2" className={styles.bsTitle}>
+        🧱 BuildStream desktop family
+      </Heading>
+      <p className={styles.bsLede}>
+        <strong>Tromsø</strong> (KDE) and <strong>XFCE Linux</strong> are built
+        with <a href="https://buildstream.build">BuildStream</a> — a complete
+        desktop assembled from source on freedesktop-sdk with reproducible
+        pipelines, the same lineage as GNOME OS. They're associated with these
+        upstream BuildStream desktop projects, each covering a different desktop:
+      </p>
+      <div className={styles.bsGrid}>
+        {BUILDSTREAM_UPSTREAMS.map((u) => (
+          <a key={u.url} href={u.url} className={styles.bsCard}>
+            <span className={styles.bsBadge}>{u.desktop}</span>
+            <div>
+              <strong className={styles.bsName}>{u.name} ↗</strong>
+              <span className={styles.bsNote}>{u.note}</span>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}
 
 export default function Projects(): ReactNode {
   return (
@@ -23,6 +52,7 @@ export default function Projects(): ReactNode {
       </header>
       <main className="container margin-bottom--xl">
         <ProjectCards />
+        <BuildStreamFamily />
       </main>
     </Layout>
   );


### PR DESCRIPTION
Follow-up polish to the landing pages (PR #14).

## Cross-linking
- Each variant and project **doc** now opens with a "Visual overview" tip banner linking to its rich **landing page** (the landing pages already link back via their "Full docs" buttons).
- The sidebar gains a **🐟 Variants** showcase section linking to the four landing pages, with the detailed reference docs nested beneath.

## Automated desktop screenshots
- New **`DesktopScreenshots`** component renders the real per-desktop screenshots captured weekly by the tunaOS `weekly-qcow2-screenshots` workflow, loaded from `download.tunaos.org/screenshots/<variant>-<flavor>-latest.png`.
- Wired into each variant landing page between the desktop line-up and features.
- Degrades gracefully: any combo not yet published (404) is hidden client-side; if none load, the section disappears — so pages look right whether or not R2 is populated yet.
- Companion workflow change is in **tuna-os/tunaOS** ("publish weekly desktop screenshots to R2").

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)