### PR TITLE
fix(docs): correct BuildStream family framing (Tromsø = Aurora KDE layer)

### DIFF
--- a/src/components/ProjectLanding/index.tsx
+++ b/src/components/ProjectLanding/index.tsx
@@ -130,9 +130,9 @@ function BuildStreamFamily({project}: {project: Project}): ReactNode {
         <div className={styles.sectionHead}>
           <Heading as="h2">Part of the BuildStream desktop family</Heading>
           <p>
-            {project.name} builds a complete desktop from source on freedesktop-sdk with
-            reproducible pipelines — the same lineage as GNOME OS. It's associated with these
-            upstream BuildStream desktop projects:
+            {project.name} is built with BuildStream — an Aurora-style layer on a vanilla
+            desktop base, the same model as Project Bluefin's Dakota (GNOME). It sits
+            alongside these sibling BuildStream desktop layers:
           </p>
         </div>
         <div className={styles.otherGrid}>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -38,28 +38,22 @@ export const STATUS_LABELS: Record<ProjectStatus, string> = {
   internal: 'Internal',
 };
 
-// The wider BuildStream "desktop from source" ecosystem that TunaOS's
-// BuildStream images (Tromsø/KDE, XFCE Linux) are modeled on and associated
-// with. Each builds a complete desktop on freedesktop-sdk with reproducible
-// pipelines — the same lineage as GNOME OS.
+// Sibling BuildStream "Aurora-style" desktop layers — opinionated images that
+// layer customizations on top of a vanilla desktop base (GNOME OS /
+// gnome-build-meta, KDE Linux / kde-build-meta, etc.). Tromsø is the KDE member
+// of this family; these are its GNOME and Niri counterparts.
 export const BUILDSTREAM_UPSTREAMS: {desktop: string; name: string; url: string; note: string}[] = [
   {
     desktop: 'GNOME',
     name: 'Dakota (Project Bluefin)',
     url: 'https://projectbluefin.io/dakota/',
-    note: 'The BuildStream for Bluefin — the reference TunaOS Tromsø is modeled on.',
+    note: 'Project Bluefin’s BuildStream layer on GNOME OS — the reference Tromsø is modeled on.',
   },
   {
     desktop: 'Niri',
     name: 'zirconium-hawaii',
     url: 'https://github.com/zirconium-dev/zirconium-hawaii/tree/stable',
     note: 'Opinionated Niri bootc image built on freedesktop-sdk (a.k.a. Niri OS).',
-  },
-  {
-    desktop: 'KDE',
-    name: 'tuna-os/kde-build-meta',
-    url: 'https://github.com/tuna-os/tromso',
-    note: 'The KDE .bst elements that Tromsø builds on — the KDE analogue of gnome-build-meta.',
   },
 ];
 

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -13,11 +13,12 @@ function BuildStreamFamily(): ReactNode {
         🧱 BuildStream desktop family
       </Heading>
       <p className={styles.bsLede}>
-        <strong>Tromsø</strong> (KDE) and <strong>XFCE Linux</strong> are built
-        with <a href="https://buildstream.build">BuildStream</a> — a complete
-        desktop assembled from source on freedesktop-sdk with reproducible
-        pipelines, the same lineage as GNOME OS. They're associated with these
-        upstream BuildStream desktop projects, each covering a different desktop:
+        <strong>Tromsø</strong> is the KDE counterpart to Project Bluefin's{' '}
+        <strong>Dakota</strong> (GNOME) — an Aurora-style layer built with{' '}
+        <a href="https://buildstream.build">BuildStream</a> on top of the vanilla
+        KDE Linux base (<code>kde-build-meta</code>), just as Dakota layers on{' '}
+        <code>gnome-build-meta</code>. <strong>XFCE Linux</strong> is built the
+        same way. Tromsø sits alongside these sibling BuildStream desktop layers:
       </p>
       <div className={styles.bsGrid}>
         {BUILDSTREAM_UPSTREAMS.map((u) => (


### PR DESCRIPTION
Corrects the BuildStream family relationships:

- **Tromsø** is the KDE counterpart to Project Bluefin's **Dakota** (GNOME) — an Aurora-style layer built on the **vanilla KDE Linux base** (`kde-build-meta`), the same way Dakota layers on `gnome-build-meta`.
- `kde-build-meta` is that vanilla base, **not** a peer project — removed as a linked sibling (kept only as descriptive prose).
- The sibling BuildStream desktop layers we link are **Dakota** (GNOME) and **zirconium-hawaii** (Niri).

Copy on `/projects` and the BuildStream project landing pages updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)