### PR TITLE
fix(types): clear tsc errors in dakota, hawaii, and projects.ts

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -250,6 +250,7 @@ export const PROJECTS: Project[] = [
   {
     id: 'hawaii',
     emoji: '🌺',
+    name: 'Zirconium Hawaii',
     status: 'experimental',
     tagline: 'Zirconium, rebuilt on freedesktop-sdk. Closer to the source.',
     lede:

--- a/src/pages/dakota.tsx
+++ b/src/pages/dakota.tsx
@@ -1,8 +1,9 @@
+import type {ReactNode} from 'react';
 import ProjectLanding from '@site/src/components/ProjectLanding';
 import {PROJECTS} from '@site/src/data/projects';
 
 const project = PROJECTS.find((p) => p.id === 'dakota')!;
 
-export default function Dakota(): JSX.Element {
+export default function Dakota(): ReactNode {
   return <ProjectLanding project={project} />;
 }

--- a/src/pages/hawaii.tsx
+++ b/src/pages/hawaii.tsx
@@ -1,8 +1,9 @@
+import type {ReactNode} from 'react';
 import ProjectLanding from '@site/src/components/ProjectLanding';
 import {PROJECTS} from '@site/src/data/projects';
 
 const project = PROJECTS.find((p) => p.id === 'hawaii')!;
 
-export default function Hawaii(): JSX.Element {
+export default function Hawaii(): ReactNode {
   return <ProjectLanding project={project} />;
 }


### PR DESCRIPTION
Clears the three pre-existing `tsc` errors on `main` (surfaced while merging #17):

- `src/data/projects.ts` — the **Zirconium Hawaii** project entry was missing the required `name` field (`TS2741`).
- `src/pages/dakota.tsx` / `src/pages/hawaii.tsx` — used the unavailable `JSX.Element` namespace (`TS2503`); switched to `ReactNode` to match every other page in `src/pages`.

✅ `npm run typecheck` exits clean; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)