### PR TITLE
chore: enable Renovate with automerge for minor/patch/digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Enables Renovate bot for this repo with automerge enabled for minor, patch, pin, and digest dependency updates.